### PR TITLE
Added badge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Indicator of project health (i.e. is this project dead?)
     - [ ] Issue stats
 - [ ] Calculate aggregate "health" or "activity" score
 - [ ] Persist scores (database)
-- [ ] Generate "badge" with score
+- [x] Generate "badge" with score
 
 #### Admin/Ops
 

--- a/badge.go
+++ b/badge.go
@@ -1,0 +1,27 @@
+package main
+
+func getBadge(grade string) string {
+
+	var color string
+
+	switch grade {
+	case "A":
+		color = "brightgreen"
+	case "B":
+		color = "green"
+	case "C":
+		color = "yellowgreen"
+	case "D":
+		color = "yellow"
+	case "E":
+		color = "orange"
+	case "F":
+		color = "red"
+	default:
+		color = "grey"
+	}
+
+	url := "https://img.shields.io/badge/Project_Health-" + grade + "-" + color + ".svg?style=flat&link=http://github.com/140proof.com/oss-health"
+
+	return url
+}

--- a/http.go
+++ b/http.go
@@ -112,7 +112,7 @@ func configureClient() {
 
 	err := godotenv.Load()
 	if err != nil {
-		log.Fatal("Error loading .env file")
+		// No .env, so get settings from ENV
 	}
 
 	t := &oauth.Transport{


### PR DESCRIPTION
Currently it's a super hacky/lazy workaround.
The endpoint simply proxies the request (with some preset parameters) to the [shields.io](http://shields.io) service.